### PR TITLE
fix/blog-links

### DIFF
--- a/src/.vuepress/components/BlogPostPreview.vue
+++ b/src/.vuepress/components/BlogPostPreview.vue
@@ -28,7 +28,7 @@ export default {
         <h3 class="blog-post__title">{{ item.frontmatter.title }}</h3>
         <p v-if="item.frontmatter.excerpt">{{ item.frontmatter.excerpt }}</p>
         <p v-if="item.readingTime">Estimated time: {{ item.readingTime.text }}</p>
-        <a class="button blog-post__button " :href="item.path">Read More ></a>
+        <router-link class="button blog-post__button" :to="item.path">Read More ></router-link>
     </section>
 </template>
 


### PR DESCRIPTION
I've noticed that blog page list is using a regular anchor tag and not leveraging client routing and thus the whole page was refreshing on clicking Read More.

This should fix it.

DISCLAIMER: I'm not very vue literate so I might be way off :)