### PR TITLE
i18n: Add locale check to blog and archive list

### DIFF
--- a/src/.vuepress/components/ArchiveList.vue
+++ b/src/.vuepress/components/ArchiveList.vue
@@ -19,12 +19,18 @@ export default {
                 return this.pages.filter(item => {
                     const isBlogPost = !!item.frontmatter.blog
                     const isReadyToPublish = new Date(item.frontmatter.date) <= new Date()
+                    // check for locales
+                    let isCurrentLocale = true;
+                    if(this.$site.locales) {
+                        const localePath = this.$route.path.split('/')[1] || "";
+                        isCurrentLocale = item.relativePath.startsWith(localePath);   
+                    }
                     // check if tags contain any of the selected tags
                     // const hasTags = item.frontmatter.tags && item.frontmatter.tags.some(tag => this.selectedTags.includes(tag))
                     // check if tags contain all of the selected tags
                     const hasTags = !!item.frontmatter.tags && this.selectedTags.every((tag) => item.frontmatter.tags.includes(tag))
 
-                    if (!isBlogPost || !isReadyToPublish || (this.selectedTags.length > 0 && !hasTags)){ 
+                    if (!isBlogPost || !isReadyToPublish || (this.selectedTags.length > 0 && !hasTags) || !isCurrentLocale){ 
                         return false
                     }
 

--- a/src/.vuepress/components/BlogPostList.vue
+++ b/src/.vuepress/components/BlogPostList.vue
@@ -28,10 +28,16 @@ export default {
                 return this.pages.filter(item => {
                     const isBlogPost = !!item.frontmatter.blog
                     const isReadyToPublish = new Date(item.frontmatter.date) <= new Date()
+                     // check for locales
+                    let isCurrentLocale = true;
+                    if(this.$site.locales) {
+                        const localePath = this.$route.path.split('/')[1] || "";
+                        isCurrentLocale = item.relativePath.startsWith(localePath);   
+                    }
                     // check if tags contain all of the selected tags
                     const hasTags = !!item.frontmatter.tags && this.selectedTags.every((tag) => item.frontmatter.tags.includes(tag))
 
-                    if (!isBlogPost || !isReadyToPublish || (this.selectedTags.length > 0 && !hasTags)){ 
+                    if (!isBlogPost || !isReadyToPublish || (this.selectedTags.length > 0 && !hasTags) || !isCurrentLocale){ 
                         return false
                     }
 


### PR DESCRIPTION
Thanks for the great project, I really enjoy working with it. 

I want to make Blog Posts in two languages. The [i18n support in Vuepress](https://vuepress.vuejs.org/guide/i18n.html#site-level-i18n-config) uses a folder with translations of each page. This isn't working in the BlogPostList and ArchiveList, since you use ```$site.pages``` and then filter them for ```frontmatter.blog```. And ```$site.pages``` will return all pages in subfolders, even if they are meant as translations. Thus, all translations will appear in the Blog Post list at the same time. 
Everything else appears to work fine. 

My proposed solution is to filter for the first part of the relative path. 

Note that this won't work on the '/' path - which is fine since the BlogPostList isn't used on the Front Page, otherwise the edge case has to be checked as well. 