### PR TITLE
added lacking `moment` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@vuepress/plugin-google-analytics": "~1.0.0-alpha.0",
     "@vuepress/theme-default": "^1.2.0",
+    "moment": "^2.29.1",
     "vuepress": "~1.0.0-alpha.30",
     "vuepress-plugin-janitor": "1.0.0",
     "vuepress-plugin-reading-time": "0.1.1",


### PR DESCRIPTION
Following instructions on [docs](https://vuepress-blog-boilerplate.bencodezen.io/learn/#installation) page after running last command - `npm run dev` - app started but in browser console an error about `moment` dependency shows up.